### PR TITLE
USBHCD: Fix enumeration of some High-Speed devices

### DIFF
--- a/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_hcd.c
+++ b/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_hcd.c
@@ -375,6 +375,8 @@ HAL_StatusTypeDef HAL_HCD_HC_SubmitRequest(HCD_HandleTypeDef *hhcd,
   if (token == 0U)
   {
     hhcd->hc[ch_num].data_pid = HC_PID_SETUP;
+    /* Clear do_ping in case previous transfer Status stage ended with NYET */
+    hhcd->hc[ch_num].do_ping = 0U;
   }
   else
   {


### PR DESCRIPTION
Some USB devices, e.g. Kingston DataTraveler 3.0 (VID 0x0951 PID 0x1666)
do end the Control transfer Status stage with NYET. Such devices did not
enumerate properly with the STM32 USB Host Library.

This change fixes enumeration of such devices by clearing any
potentially pending do_ping flag when sending SETUP token.

Without this change such devices did not enumerate and the USB host
debug messages contained:
  USB Device Attached
  PID: 1666h
  VID: 951h
  ERROR: Control error
  ERROR: Control error
  ERROR: Control error
  ERROR: Control error
  ERROR: Control error

OpenVizsla USB sniffer capture revelaved following:
  * SETUP stage
    * SETUP [host -> address 0 endpoint 0]
    * DATA0 [80 06 00 01 00 00 08 00] [CRC16: EB 94]
    * ACK
  * DATA stage
    * IN
    * NAK
    ... the IN/NAK repeated multiple time until device was ready
    * IN
    * DATA1 [12 01 10 02 00 00 00 40] [CRC16: 55 41]
    * ACK
  * STATUS stage
    * OUT
    * DATA1 ZLP
    * NYET
  * Next transfer's SETUP stage
    * SETUP [host -> address 0 endpoint 0]
    * DATA0 [80 06 00 01 00 00 12 00] [CRC16: E0 F4]
    * ACK
  * Next transfer's DATA stage
    ... multiple IN/NAK pairs until device was ready
    * IN
    * DATA1 [12 01 10 02 00 00 00 40 51 09 66 16 01 00 01 02 03 01]
            [CRC16: 09 30]
    * ACK
  * Next transfer's STATUS stage
    * OUT
    * DATA1 ZLP
    * NYET
    * PING [address 0 endpoint 0]
    * NAK
    ... multiple PING/NAK pairs until host gave up (16 in total)

With this change the Next transfer's STATUS stage ends at NYET.
No PING tokens are seen on the wire during the enumeration.

As a reference, when xHCI controller in laptop running Windows 10
enumerates the device, it does not send any PING tokens as a result
of STATUS stage ending with NYET.

## IMPORTANT INFORMATION 

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics only after a **Contributor License Agreement (CLA)** mechanism has been deployed.
* We are currently working on the set-up of this procedure. 
  