### PR TITLE
Fix a bug in osEventFlagsWait() when called with the osFlagsWaitAll flag

### DIFF
--- a/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/cmsis_os2.c
+++ b/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/cmsis_os2.c
@@ -1176,7 +1176,7 @@ uint32_t osEventFlagsWait (osEventFlagsId_t ef_id, uint32_t flags, uint32_t opti
     rflags = xEventGroupWaitBits (hEventGroup, (EventBits_t)flags, exit_clr, wait_all, (TickType_t)timeout);
 
     if (options & osFlagsWaitAll) {
-      if (flags != rflags) {
+      if ((flags & rflags) != flags) {
         if (timeout > 0U) {
           rflags = (uint32_t)osErrorTimeout;
         } else {


### PR DESCRIPTION
Bring in a bugfix from [https://github.com/ARM-software/CMSIS-FreeRTOS/commit/78de2a6322d2b0a00b0ea9ce827e98cbfb89e795](https://github.com/ARM-software/CMSIS-FreeRTOS/commit/78de2a6322d2b0a00b0ea9ce827e98cbfb89e795).  The log message there reads as follows:

> Fixed group flags comparison, when waiting on all flags (osFlagsWaitAll).
> Previous implementation invokes fail every time, when other flags (those
> we don't wait for) are set.  This fix only compares flags specified to
> wait for, as API docs suggests.
> 

This fixes a bug in `osEventFlagsWait()` that appears when it is called with the `osFlagsWaitAll` flag.  If you are waiting on, for example, `FLAG_A | FLAG_B` and those flags become set along with another flag `FLAG_C`, then `osEventFlagsWait()` returns a failure indication rather than succeeding as it should.
## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeF7/blob/master/CONTRIBUTING.md) file.
