### PR TITLE
Fix HAL_SD_ReadBlocks() working without -Os optimization flag

### DIFF
--- a/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_sd.c
+++ b/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_sd.c
@@ -656,6 +656,7 @@ HAL_StatusTypeDef HAL_SD_ReadBlocks(SD_HandleTypeDef *hsd, uint8_t *pData, uint3
           tempbuff++;
           dataremaining--;
         }
+        continue;
       }
 
       if(((HAL_GetTick()-tickstart) >=  Timeout) || (Timeout == 0U))


### PR DESCRIPTION
There is trouble when I use HAL_SD_ReadBlocks() without compiler optimization flag -Os.

It seems that FIFO can overflow if we pass all checkings. After I added 'continue;' after reading a pack from FIFO the trouble seems disappeared
