### PR TITLE
stm32f7xx_hal_crc: Improve state control during work with CRC. 

### DIFF
--- a/Drivers/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_crc.h
+++ b/Drivers/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_crc.h
@@ -48,8 +48,6 @@ typedef enum
   HAL_CRC_STATE_RESET     = 0x00U,  /*!< CRC not yet initialized or disabled */
   HAL_CRC_STATE_READY     = 0x01U,  /*!< CRC initialized and ready for use   */
   HAL_CRC_STATE_BUSY      = 0x02U,  /*!< CRC internal process is ongoing     */
-  HAL_CRC_STATE_TIMEOUT   = 0x03U,  /*!< CRC timeout state                   */
-  HAL_CRC_STATE_ERROR     = 0x04U   /*!< CRC error state                     */
 } HAL_CRC_StateTypeDef;
 
 /**

--- a/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_crc.c
+++ b/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_crc.c
@@ -289,6 +289,12 @@ uint32_t HAL_CRC_Accumulate(CRC_HandleTypeDef *hcrc, uint32_t pBuffer[], uint32_
   uint32_t index;      /* CRC input data buffer index */
   uint32_t temp = 0U;  /* CRC output (read from hcrc->Instance->DR register) */
 
+  /* Check the CRC peripheral state */
+  if (hcrc->State == HAL_CRC_STATE_BUSY)
+  {
+    return HAL_BUSY;
+  }
+
   /* Change CRC peripheral state */
   hcrc->State = HAL_CRC_STATE_BUSY;
 
@@ -341,6 +347,12 @@ uint32_t HAL_CRC_Calculate(CRC_HandleTypeDef *hcrc, uint32_t pBuffer[], uint32_t
   uint32_t index;      /* CRC input data buffer index */
   uint32_t temp = 0U;  /* CRC output (read from hcrc->Instance->DR register) */
 
+  /* Check the CRC peripheral state */
+  if (hcrc->State == HAL_CRC_STATE_BUSY)
+  {
+    return HAL_BUSY;
+  }
+  
   /* Change CRC peripheral state */
   hcrc->State = HAL_CRC_STATE_BUSY;
 


### PR DESCRIPTION
Now we get HAL_Busy when CRC module is busy. Before changes, the API has allowed invoke HAL_CRC_Calculate/HAL_CRC_Acumulate multiple times during works (thread safety)

Also remove unused crc states.

