### PR TITLE
fix function description typo in usbd_core.c

### DIFF
--- a/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_core.c
+++ b/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_core.c
@@ -142,7 +142,7 @@ USBD_StatusTypeDef USBD_Init(USBD_HandleTypeDef *pdev,
 
 /**
   * @brief  USBD_DeInit
-  *         Re-Initialize the device library
+  *         De-Initialize the device library
   * @param  pdev: device instance
   * @retval status: status
   */


### PR DESCRIPTION
Previously - 
```
/**
  * @brief  USBD_DeInit
  *         Re-Initialize the device library
  * @param  pdev: device instance
  * @retval status: status
  */
```
Afterwards - 
```
/**
  * @brief  USBD_DeInit
  *         De-Initialize the device library
  * @param  pdev: device instance
  * @retval status: status
  */
