### PR TITLE
nt35510: fix setting of DPRSLCTR register

### DIFF
--- a/Drivers/BSP/Components/nt35510/nt35510.c
+++ b/Drivers/BSP/Components/nt35510/nt35510.c
@@ -100,7 +100,7 @@ uint8_t NT35510_Init(uint32_t ColorCoding, uint32_t orientation)
   const uint8_t nt35510_reg16[] = {0x55, 0xAA, 0x52, 0x08, 0x00, 0xF0};
   const uint8_t nt35510_reg17[] = {0xFC, 0x00, 0xB1};
   const uint8_t nt35510_reg18[] = {0xB6, 0x03};
-  const uint8_t nt35510_reg19[] = {0xB5, 0x51};
+  const uint8_t nt35510_reg19[] = {0xB5, 0x50};
   const uint8_t nt35510_reg20[] = {0x00, 0x00, 0xB7};
   const uint8_t nt35510_reg21[] = {0x01, 0x02, 0x02, 0x02, 0xB8};
   const uint8_t nt35510_reg22[] = {0x00, 0x00, 0x00, 0xBC};


### PR DESCRIPTION
As described in the NT35510 Application Note V0.04, the DPRSLCTR register (Display Resolution Control - B500h) needs to be set to 50h for the 480x800 display resolution.

Fixes: 6eed5bb15304 ("Update STM32F769I-Discovery BSP drivers to support new nt35510 component available on new LCD DSI daughter board MB1166 RevA09 and above versions.")

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeF7/blob/master/CONTRIBUTING.md) file.
