### PR TITLE
Fix GCC Linker Section Mismatch for Ethernet DMA Descriptors (LwIP/mbedTLS)

### DIFF
--- a/Projects/STM32746G-Discovery/Applications/LwIP/LwIP_HTTP_Server_Netconn_RTOS/SW4STM32/STM32746G_DISCOVERY/STM32F746NGHx_FLASH.ld
+++ b/Projects/STM32746G-Discovery/Applications/LwIP/LwIP_HTTP_Server_Netconn_RTOS/SW4STM32/STM32746G_DISCOVERY/STM32F746NGHx_FLASH.ld
@@ -162,7 +162,7 @@ SECTIONS
   }
 
    .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD) : { *(.TxDescripSection) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD) : { *(.TxDecripSection) } >Memory_B2
 }
 

--- a/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_HTTP_Server_Netconn_RTOS/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
+++ b/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_HTTP_Server_Netconn_RTOS/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD): { *(.DMATxDscrTab_section) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD): { *(.TxDecripSection) } >Memory_B2
 }
 
 

--- a/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_HTTP_Server_Raw/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
+++ b/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_HTTP_Server_Raw/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD): { *(.DMATxDscrTab_section) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD): { *(.TxDecripSection) } >Memory_B2
 }
 
 

--- a/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_HTTP_Server_Socket_RTOS/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
+++ b/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_HTTP_Server_Socket_RTOS/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD): { *(.DMATxDscrTab_section) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD): { *(.TxDecripSection) } >Memory_B2
 }
 
 

--- a/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_IAP/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
+++ b/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_IAP/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD): { *(.DMATxDscrTab_section) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD): { *(.TxDecripSection) } >Memory_B2
 }
 
 

--- a/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_TCP_Echo_Client/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
+++ b/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_TCP_Echo_Client/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD): { *(.DMATxDscrTab_section) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD): { *(.TxDecripSection) } >Memory_B2
 }
 
 

--- a/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_TCP_Echo_Server/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
+++ b/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_TCP_Echo_Server/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD): { *(.DMATxDscrTab_section) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD): { *(.TxDecripSection) } >Memory_B2
 }
 
 

--- a/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_TFTP_Server/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
+++ b/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_TFTP_Server/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD): { *(.DMATxDscrTab_section) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD): { *(.TxDecripSection) } >Memory_B2
 }
 
 

--- a/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_UDPTCP_Echo_Server_Netconn_RTOS/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
+++ b/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_UDPTCP_Echo_Server_Netconn_RTOS/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD): { *(.DMATxDscrTab_section) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD): { *(.TxDecripSection) } >Memory_B2
 }
 
 

--- a/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_UDP_Echo_Client/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
+++ b/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_UDP_Echo_Client/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD): { *(.DMATxDscrTab_section) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD): { *(.TxDecripSection) } >Memory_B2
 }
 
 

--- a/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_UDP_Echo_Server/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
+++ b/Projects/STM32756G_EVAL/Applications/LwIP/LwIP_UDP_Echo_Server/SW4STM32/STM327x6G_EVAL/STM32F756NGHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD): { *(.DMATxDscrTab_section) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD): { *(.TxDecripSection) } >Memory_B2
 }
 
 

--- a/Projects/STM32F746ZG-Nucleo/Applications/LwIP/LwIP_HTTP_Server_Netconn_RTOS/SW4STM32/STM32746G_Nucleo/STM32F746ZGTx_FLASH.ld
+++ b/Projects/STM32F746ZG-Nucleo/Applications/LwIP/LwIP_HTTP_Server_Netconn_RTOS/SW4STM32/STM32746G_Nucleo/STM32F746ZGTx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
    .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD) : { *(.TxDescripSection) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD) : { *(.TxDecripSection) } >Memory_B2
 }
 
 

--- a/Projects/STM32F769I-Discovery/Applications/LwIP/LwIP_HTTP_Server_Netconn_RTOS/SW4STM32/STM32F769I_DISCOVERY/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I-Discovery/Applications/LwIP/LwIP_HTTP_Server_Netconn_RTOS/SW4STM32/STM32F769I_DISCOVERY/STM32F769NIHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD) : { *(.DMATxDscrTab_section) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD) : { *(.TxDecripSection) } >Memory_B2
 }
 
 

--- a/Projects/STM32F769I-Discovery/Applications/LwIP/LwIP_HTTP_Server_Socket_RTOS/SW4STM32/STM32F769I_DISCOVERY/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I-Discovery/Applications/LwIP/LwIP_HTTP_Server_Socket_RTOS/SW4STM32/STM32F769I_DISCOVERY/STM32F769NIHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD) : { *(.DMATxDscrTab_section) } >Memory_B2
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD) : { *(.TxDecripSection) } >Memory_B2
 }
 
 

--- a/Projects/STM32F769I-Discovery/Applications/mbedTLS/SSL_Client/SW4STM32/STM32F769I_Discovery/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I-Discovery/Applications/mbedTLS/SSL_Client/SW4STM32/STM32F769I_Discovery/STM32F769NIHx_FLASH.ld
@@ -164,7 +164,7 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDescripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
   .TxDescripSection (NOLOAD) : { *(.TxDescripSection) } >Memory_B2
   .RxBUF (NOLOAD) : { *(.RxBUF) } >Memory_B3
   .TxBUF (NOLOAD) : { *(.TxBUF) } >Memory_B4

--- a/Projects/STM32F769I-Discovery/Applications/mbedTLS/SSL_Server/SW4STM32/STM32F769I_Discovery/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I-Discovery/Applications/mbedTLS/SSL_Server/SW4STM32/STM32F769I_Discovery/STM32F769NIHx_FLASH.ld
@@ -164,7 +164,7 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDescripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
   .TxDescripSection (NOLOAD) : { *(.TxDescripSection) } >Memory_B2
   .RxBUF (NOLOAD) : { *(.RxBUF) } >Memory_B3
   .TxBUF (NOLOAD) : { *(.TxBUF) } >Memory_B4

--- a/Projects/STM32F769I_EVAL/Applications/LwIP/LwIP_HTTP_Server_Netconn_RTOS/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/LwIP/LwIP_HTTP_Server_Netconn_RTOS/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD) : { *(.DMATxDscrTab_section) } >Memory_B2 
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD) : { *(.TxDecripSection) } >Memory_B2 
 }
 
 

--- a/Projects/STM32F769I_EVAL/Applications/LwIP/LwIP_HTTP_Server_Raw/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/LwIP/LwIP_HTTP_Server_Raw/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD) : { *(.DMATxDscrTab_section) } >Memory_B2 
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD) : { *(.TxDecripSection) } >Memory_B2 
 }
 
 

--- a/Projects/STM32F769I_EVAL/Applications/LwIP/LwIP_HTTP_Server_Socket_RTOS/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/LwIP/LwIP_HTTP_Server_Socket_RTOS/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD) : { *(.DMATxDscrTab_section) } >Memory_B2 
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD) : { *(.TxDecripSection) } >Memory_B2 
 }
 
 

--- a/Projects/STM32F769I_EVAL/Applications/LwIP/LwIP_IAP/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/LwIP/LwIP_IAP/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD) : { *(.DMATxDscrTab_section) } >Memory_B2 
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD) : { *(.TxDecripSection) } >Memory_B2 
 }
 
 

--- a/Projects/STM32F769I_EVAL/Applications/LwIP/LwIP_StreamingServer/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/LwIP/LwIP_StreamingServer/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
@@ -162,8 +162,8 @@ SECTIONS
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
-  .RxDecripSection (NOLOAD) : { *(.RxDescripSection) } >Memory_B1
-  .TxDescripSection (NOLOAD) : { *(.DMATxDscrTab_section) } >Memory_B2 
+  .RxDecripSection (NOLOAD) : { *(.RxDecripSection) } >Memory_B1
+  .TxDecripSection (NOLOAD) : { *(.TxDecripSection) } >Memory_B2 
 }
 
 


### PR DESCRIPTION
### Description
This PR fixes a critical memory placement issue affecting LwIP and mbedTLS applications when built with GCC (SW4STM32/STM32CubeIDE).

### The Issue
The `ethernetif.c` source files define DMA descriptors using the section names `.RxDecripSection` and `.TxDecripSection` (note the spelling "Decrip"). However, the GCC linker scripts (`.ld`) were expecting `.RxDescripSection` and `.DMATxDscrTab_section`.

Because of this mismatch, the linker treated the descriptors as **orphan data** and placed them in default cacheable RAM (`0x2000...`) instead of the required non-cacheable/buffered memory regions (`Memory_B1`/`Memory_B2` at `0x2007C...`).

**Consequence:** This causes Ethernet DMA corruption and network instability due to cache coherency issues on Cortex-M7.

### The Fix
I have updated the input section selectors in the `.ld` files across all affected projects (F746, F756, F769) to explicitly match the section names used in the C source code:

* `.RxDescripSection` -> `.RxDecripSection`
* `.DMATxDscrTab_section` -> `.TxDecripSection`

### Design Decision (Important)
I opted to update the **Linker Scripts** to match the existing C source (including the typo "Decrip") rather than changing the C source itself.

**Reasoning:**
1.  **Non-Invasive:** This avoids modifying user-level source files (`ethernetif.c`).
2.  **Compatibility:** MDK-ARM (Keil) and EWARM (IAR) projects already rely on the "Decrip" section names in their scatter/linker files. Changing the C source would have broken builds for those toolchains.

### Verification
* **Target:** STM32F769I-EVAL
* **Toolchain:** STM32CubeIDE (GCC)
* **Result:** Verified map file after build.
    * **Before:** Descriptors at `0x2000xxxx` (Generic RAM).
    * **After:** Descriptors correctly placed at `0x2007C000` (Rx) and `0x2007C0A0` (Tx) in `Memory_B1`/`B2`.
* **Audit:** Verified via `grep` that other boards (e.g., STM32F746G-DISCO) also use the `.RxDecripSection` naming in their source, necessitating this linker update.