### PR TITLE
fix(linker): correct several cross-toolchain memory map inconsistencies

### DIFF
--- a/Projects/STM32F767ZI-Nucleo/Applications/USB_Device/HID_Standalone/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Applications/USB_Device/HID_Standalone/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.7.5</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Applications/USB_Device/MSC_Standalone/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Applications/USB_Device/MSC_Standalone/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.7.5</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Applications/USB_Host/HID_Standalone/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Applications/USB_Host/HID_Standalone/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/FLASH/FLASH_SwapBank/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/FLASH/FLASH_SwapBank/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>
@@ -554,7 +554,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/I2C/I2C_TwoBoards_RestartAdvComIT/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/I2C/I2C_TwoBoards_RestartAdvComIT/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/I2C/I2C_TwoBoards_RestartComIT/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/I2C/I2C_TwoBoards_RestartComIT/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/I2S/I2S_DataExchangeInterrupt/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/I2S/I2S_DataExchangeInterrupt/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/IWDG/IWDG_Example/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/IWDG/IWDG_Example/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/LPTIM/LPTIM_PWMExternalClock/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/LPTIM/LPTIM_PWMExternalClock/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/LPTIM/LPTIM_PWM_LSE/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/LPTIM/LPTIM_PWM_LSE/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/LPTIM/LPTIM_PulseCounter/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/LPTIM/LPTIM_PulseCounter/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/LPTIM/LPTIM_Timeout/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/LPTIM/LPTIM_Timeout/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/PWR/PWR_CurrentConsumption/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/PWR/PWR_CurrentConsumption/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/RCC/RCC_ClockConfig/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/RCC/RCC_ClockConfig/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/RNG/RNG_MultiRNG/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/RNG/RNG_MultiRNG/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/RTC/RTC_Calendar/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/RTC/RTC_Calendar/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/SPI/SPI_FullDuplex_AdvComIT/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/SPI/SPI_FullDuplex_AdvComIT/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/SPI/SPI_FullDuplex_AdvComPolling/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/SPI/SPI_FullDuplex_AdvComPolling/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/SPI/SPI_FullDuplex_ComDMA/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/SPI/SPI_FullDuplex_ComDMA/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/SPI/SPI_FullDuplex_ComIT/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/SPI/SPI_FullDuplex_ComIT/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/SPI/SPI_FullDuplex_ComPolling/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/SPI/SPI_FullDuplex_ComPolling/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/TIM/TIM_DMA/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/TIM/TIM_DMA/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/TIM/TIM_TimeBase/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/TIM/TIM_TimeBase/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/UART/UART_Printf/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/UART/UART_Printf/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Examples/WWDG/WWDG_Example/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Examples/WWDG/WWDG_Example/MDK-ARM/Project.uvprojx
@@ -17,7 +17,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>Keil.STM32F7xx_DFP.2.3.3</PackID>
           <PackURL>http://www.keil.com/pack</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Templates/MDK-ARM/Project.uvprojx
+++ b/Projects/STM32F767ZI-Nucleo/Templates/MDK-ARM/Project.uvprojx
@@ -18,7 +18,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>STMicroelectronics.STM32F7xx_DFP.1.0.3</PackID>
           <PackURL>http://www.ST.com/</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>
@@ -814,7 +814,7 @@
           <Vendor>STMicroelectronics</Vendor>
           <PackID>STMicroelectronics.STM32F7xx_DFP.1.0.3</PackID>
           <PackURL>http://www.ST.com/</PackURL>
-          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2004FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
+          <Cpu>IROM(0x08000000-0x081FFFFF) IRAM(0x20000000-0x2007FFFF) CPUTYPE("Cortex-M7") FPU3(SFPU) CLOCK(12000000) ELITTLE</Cpu>
           <FlashUtilSpec></FlashUtilSpec>
           <StartupFile></StartupFile>
           <FlashDriverDll></FlashDriverDll>

--- a/Projects/STM32F767ZI-Nucleo/Templates/SW4STM32/STM32F767ZI_Nucleo_AXIM_FLASH/STM32F767ZITx_FLASH.ld
+++ b/Projects/STM32F767ZI-Nucleo/Templates/SW4STM32/STM32F767ZI_Nucleo_AXIM_FLASH/STM32F767ZITx_FLASH.ld
@@ -38,7 +38,7 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 MEMORY
 {
 FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 320K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 512K
 }
 
 /* Define output sections */

--- a/Projects/STM32F769I-Discovery/Applications/USB_Device/MSC_Standalone/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I-Discovery/Applications/USB_Device/MSC_Standalone/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__     = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__       = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__       = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__     = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__       = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__       = 0x2007FFFF;
 define symbol __ICFEDIT_region_ITCMRAM_start__ = 0x00000000;
 define symbol __ICFEDIT_region_ITCMRAM_end__   = 0x00003FFF;
 /*-Sizes-*/

--- a/Projects/STM32F769I-Discovery/Applications/USB_Host/MSC_Standalone/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I-Discovery/Applications/USB_Host/MSC_Standalone/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__     = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__       = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__       = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__     = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__       = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__       = 0x2007FFFF;
 define symbol __ICFEDIT_region_ITCMRAM_start__ = 0x00000000;
 define symbol __ICFEDIT_region_ITCMRAM_end__   = 0x00003FFF;
 /*-Sizes-*/

--- a/Projects/STM32F769I-Discovery/Examples/FMC/FMC_SDRAM/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I-Discovery/Examples/FMC/FMC_SDRAM/EWARM/stm32f769xx_flash.icf
@@ -5,7 +5,7 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__   = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_RAM_end__   = 0x2007FFFF;
 /*-Sizes-*/

--- a/Projects/STM32F769I-Discovery/Examples/I2C/I2C_TwoBoards_ComDMA/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I-Discovery/Examples/I2C/I2C_TwoBoards_ComDMA/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__   = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__   = 0x2000FFFF;
+define symbol __ICFEDIT_region_RAM_end__   = 0x2007FFFF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x1000;
 define symbol __ICFEDIT_size_heap__   = 0x400;

--- a/Projects/STM32F769I-Discovery/Examples/I2C/I2C_TwoBoards_ComIT/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I-Discovery/Examples/I2C/I2C_TwoBoards_ComIT/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__   = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__   = 0x2000FFFF;
+define symbol __ICFEDIT_region_RAM_end__   = 0x2007FFFF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x1000;
 define symbol __ICFEDIT_size_heap__   = 0x400;

--- a/Projects/STM32F769I-Discovery/Examples/I2C/I2C_TwoBoards_ComPolling/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I-Discovery/Examples/I2C/I2C_TwoBoards_ComPolling/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__   = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__   = 0x2000FFFF;
+define symbol __ICFEDIT_region_RAM_end__   = 0x2007FFFF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x1000;
 define symbol __ICFEDIT_size_heap__   = 0x400;

--- a/Projects/STM32F769I-Discovery/Examples/JPEG/JPEG_DecodingUsingFs_DMA/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I-Discovery/Examples/JPEG/JPEG_DecodingUsingFs_DMA/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__   = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__   = 0x2000FFFF;
+define symbol __ICFEDIT_region_RAM_end__   = 0x2007FFFF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x1000;
 define symbol __ICFEDIT_size_heap__   = 0x400;

--- a/Projects/STM32F769I-Discovery/Examples/SPI/SPI_FullDuplex_ComDMA/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I-Discovery/Examples/SPI/SPI_FullDuplex_ComDMA/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__   = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__   = 0x2000FFFF;
+define symbol __ICFEDIT_region_RAM_end__   = 0x2007FFFF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x1000;
 define symbol __ICFEDIT_size_heap__   = 0x400;

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_MultiDrives/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_MultiDrives/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__   = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__   = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__   = 0x2007FFFF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x800;
 define symbol __ICFEDIT_size_heap__   = 0x400;

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_MultiDrives/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_MultiDrives/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
@@ -37,8 +37,8 @@ _Min_Stack_Size = 0x800; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 320K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 512K
 }
 
 /* Define output sections */

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__     = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__       = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__       = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__     = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__       = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__       = 0x2007FFFF;
 define symbol __ICFEDIT_region_ITCMRAM_start__ = 0x00000000;
 define symbol __ICFEDIT_region_ITCMRAM_end__   = 0x00003FFF;
 /*-Sizes-*/

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk/SW4STM32/STM32F769I-EVAL_USBH-FS/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk/SW4STM32/STM32F769I-EVAL_USBH-FS/STM32F769NIHx_FLASH.ld
@@ -37,8 +37,8 @@ _Min_Stack_Size = 0x800; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 320K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 512K
 ITCMRAM (xrw)      : ORIGIN = 0x00000000, LENGTH = 16K
 }
 

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk/SW4STM32/STM32F769I-EVAL_USBH-HS-IN-FS/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk/SW4STM32/STM32F769I-EVAL_USBH-HS-IN-FS/STM32F769NIHx_FLASH.ld
@@ -37,8 +37,8 @@ _Min_Stack_Size = 0x800; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 320K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 512K
 ITCMRAM (xrw)      : ORIGIN = 0x00000000, LENGTH = 16K
 }
 

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk/SW4STM32/STM32F769I-EVAL_USBH-HS/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk/SW4STM32/STM32F769I-EVAL_USBH-HS/STM32F769NIHx_FLASH.ld
@@ -37,8 +37,8 @@ _Min_Stack_Size = 0x800; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 320K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 512K
 ITCMRAM (xrw)      : ORIGIN = 0x00000000, LENGTH = 16K
 }
 

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_MultipleAccess_RTOS/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_MultipleAccess_RTOS/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__   = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__   = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__   = 0x2007FFFF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x800;
 define symbol __ICFEDIT_size_heap__   = 0x400;

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_MultipleAccess_RTOS/SW4STM32/STM32F769I-EVAL_USBH-FS/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_MultipleAccess_RTOS/SW4STM32/STM32F769I-EVAL_USBH-FS/STM32F769NIHx_FLASH.ld
@@ -37,8 +37,8 @@ _Min_Stack_Size = 0x800; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 320K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 512K
 }
 
 /* Define output sections */

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_MultipleAccess_RTOS/SW4STM32/STM32F769I-EVAL_USBH-HS-IN-FS/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_MultipleAccess_RTOS/SW4STM32/STM32F769I-EVAL_USBH-HS-IN-FS/STM32F769NIHx_FLASH.ld
@@ -37,8 +37,8 @@ _Min_Stack_Size = 0x800; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 320K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 512K
 }
 
 /* Define output sections */

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_MultipleAccess_RTOS/SW4STM32/STM32F769I-EVAL_USBH-HS/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_MultipleAccess_RTOS/SW4STM32/STM32F769I-EVAL_USBH-HS/STM32F769NIHx_FLASH.ld
@@ -37,8 +37,8 @@ _Min_Stack_Size = 0x800; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 320K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 512K
 }
 
 /* Define output sections */

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_RTOS/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_RTOS/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__   = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__   = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__   = 0x2007FFFF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x800;
 define symbol __ICFEDIT_size_heap__   = 0x400;

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_RTOS/SW4STM32/STM32F769I-EVAL_USBH-FS/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_RTOS/SW4STM32/STM32F769I-EVAL_USBH-FS/STM32F769NIHx_FLASH.ld
@@ -37,8 +37,8 @@ _Min_Stack_Size = 0x800; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 320K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 512K
 }
 
 /* Define output sections */

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_RTOS/SW4STM32/STM32F769I-EVAL_USBH-HS-IN-FS/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_RTOS/SW4STM32/STM32F769I-EVAL_USBH-HS-IN-FS/STM32F769NIHx_FLASH.ld
@@ -37,8 +37,8 @@ _Min_Stack_Size = 0x800; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 320K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 512K
 }
 
 /* Define output sections */

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_RTOS/SW4STM32/STM32F769I-EVAL_USBH-HS/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_USBDisk_RTOS/SW4STM32/STM32F769I-EVAL_USBH-HS/STM32F769NIHx_FLASH.ld
@@ -37,8 +37,8 @@ _Min_Stack_Size = 0x800; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 320K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 512K
 }
 
 /* Define output sections */

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_uSD/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_uSD/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__   = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__   = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__   = 0x2007FFFF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x800;
 define symbol __ICFEDIT_size_heap__   = 0x800;

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_uSD/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_uSD/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
@@ -37,8 +37,8 @@ _Min_Stack_Size = 0x800; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 320K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 512K
 }
 
 /* Define output sections */

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_uSD_RTOS/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_uSD_RTOS/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__   = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__   = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__   = 0x2007FFFF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x2000;
 define symbol __ICFEDIT_size_heap__   = 0x800;

--- a/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_uSD_RTOS/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
+++ b/Projects/STM32F769I_EVAL/Applications/FatFs/FatFs_uSD_RTOS/SW4STM32/STM32F769I_EVAL/STM32F769NIHx_FLASH.ld
@@ -37,8 +37,8 @@ _Min_Stack_Size = 0x2000; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 320K
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 2048K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 512K
 }
 
 /* Define output sections */

--- a/Projects/STM32F769I_EVAL/Applications/USB_Device/CustomHID_Standalone/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/USB_Device/CustomHID_Standalone/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__     = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__       = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__       = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__     = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__       = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__       = 0x2007FFFF;
 define symbol __ICFEDIT_region_ITCMRAM_start__ = 0x00000000;
 define symbol __ICFEDIT_region_ITCMRAM_end__   = 0x00003FFF;
 /*-Sizes-*/

--- a/Projects/STM32F769I_EVAL/Applications/USB_Device/DualCore_Standalone/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/USB_Device/DualCore_Standalone/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__   = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__   = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__   = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__   = 0x2007FFFF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x400;
 define symbol __ICFEDIT_size_heap__   = 0x500;

--- a/Projects/STM32F769I_EVAL/Applications/USB_Host/CDC_Standalone/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/USB_Host/CDC_Standalone/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__     = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__       = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__       = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__     = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__       = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__       = 0x2007FFFF;
 define symbol __ICFEDIT_region_ITCMRAM_start__ = 0x00000000;
 define symbol __ICFEDIT_region_ITCMRAM_end__   = 0x00003FFF;
 /*-Sizes-*/

--- a/Projects/STM32F769I_EVAL/Applications/USB_Host/DualCore_Standalone/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/USB_Host/DualCore_Standalone/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__     = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__       = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__       = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__     = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__       = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__       = 0x2007FFFF;
 define symbol __ICFEDIT_region_ITCMRAM_start__ = 0x00000000;
 define symbol __ICFEDIT_region_ITCMRAM_end__   = 0x00003FFF;
 /*-Sizes-*/

--- a/Projects/STM32F769I_EVAL/Applications/USB_Host/DynamicSwitch_Standalone/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/USB_Host/DynamicSwitch_Standalone/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__     = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__       = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__       = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__     = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__       = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__       = 0x2007FFFF;
 define symbol __ICFEDIT_region_ITCMRAM_start__ = 0x00000000;
 define symbol __ICFEDIT_region_ITCMRAM_end__   = 0x00003FFF;
 /*-Sizes-*/

--- a/Projects/STM32F769I_EVAL/Applications/USB_Host/HID_RTOS/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/USB_Host/HID_RTOS/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__     = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__       = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__       = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__     = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__       = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__       = 0x2007FFFF;
 define symbol __ICFEDIT_region_ITCMRAM_start__ = 0x00000000;
 define symbol __ICFEDIT_region_ITCMRAM_end__   = 0x00003FFF;
 /*-Sizes-*/

--- a/Projects/STM32F769I_EVAL/Applications/USB_Host/HID_Standalone/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/USB_Host/HID_Standalone/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__     = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__       = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__       = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__     = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__       = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__       = 0x2007FFFF;
 define symbol __ICFEDIT_region_ITCMRAM_start__ = 0x00000000;
 define symbol __ICFEDIT_region_ITCMRAM_end__   = 0x00003FFF;
 /*-Sizes-*/

--- a/Projects/STM32F769I_EVAL/Applications/USB_Host/MSC_RTOS/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/USB_Host/MSC_RTOS/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__     = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__       = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__       = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__     = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__       = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__       = 0x2007FFFF;
 define symbol __ICFEDIT_region_ITCMRAM_start__ = 0x00000000;
 define symbol __ICFEDIT_region_ITCMRAM_end__   = 0x00003FFF;
 /*-Sizes-*/

--- a/Projects/STM32F769I_EVAL/Applications/USB_Host/MSC_Standalone/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/USB_Host/MSC_Standalone/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__     = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__       = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__       = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__     = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__       = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__       = 0x2007FFFF;
 define symbol __ICFEDIT_region_ITCMRAM_start__ = 0x00000000;
 define symbol __ICFEDIT_region_ITCMRAM_end__   = 0x00003FFF;
 /*-Sizes-*/

--- a/Projects/STM32F769I_EVAL/Applications/USB_Host/MTP_Standalone/EWARM/stm32f769xx_flash.icf
+++ b/Projects/STM32F769I_EVAL/Applications/USB_Host/MTP_Standalone/EWARM/stm32f769xx_flash.icf
@@ -5,9 +5,9 @@
 define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__     = 0x08000000;
-define symbol __ICFEDIT_region_ROM_end__       = 0x080FFFFF;
+define symbol __ICFEDIT_region_ROM_end__       = 0x081FFFFF;
 define symbol __ICFEDIT_region_RAM_start__     = 0x20000000;
-define symbol __ICFEDIT_region_RAM_end__       = 0x2004FFFF;
+define symbol __ICFEDIT_region_RAM_end__       = 0x2007FFFF;
 define symbol __ICFEDIT_region_ITCMRAM_start__ = 0x00000000;
 define symbol __ICFEDIT_region_ITCMRAM_end__   = 0x00003FFF;
 /*-Sizes-*/


### PR DESCRIPTION
Not tied to a specific existing issue - found by systematically cross-checking each example's GCC (SW4STM32)/IAR (EWARM)/Keil (MDK-ARM) linker scripts against each other and against known-good `Templates`/`Templates_LL` sibling projects for the same chip, following the same methodology already used for STM32CubeG4, STM32CubeWB, and STM32CubeU5 in this repo family.

### 1. STM32F769I-Discovery and STM32F769I_EVAL (STM32F769NIH6, 2MB flash / 512KB RAM) - 18 examples, EWARM alone wrong

EWARM's `.icf` declared only 1MB flash (`ROM_end=0x080FFFFF`) and either 320K or 64K RAM instead of the chip's real 2MB / 512K, across 18 ordinary HAL peripheral examples on both boards. GCC and Keil both already correctly use the full 2MB/512K for the same projects - confirmed via `_estack` (computed as `0x20080000` = `0x20000000 + 512K`) and each project's own GCC `MEMORY` block. Fixed all 18 EWARM files to `ROM_end=0x081FFFFF`, `RAM_end=0x2007FFFF`.

### 2. STM32F769I_EVAL FatFs example family (6 project identities, 18 files) - EWARM *and* GCC both wrong

Both EWARM (`.icf`) and GCC (`.ld`, across the USB-host-mode SW4STM32 variants) declared only 1MB flash / 320K RAM - only Keil (via its `.uvprojx` `<Cpu>` line, `IRAM(0x20000000-0x2007FFFF) IROM(0x8000000-0x81FFFFF)`) correctly used the full 2MB flash / 512K RAM. This is a "2-of-3-toolchains-wrong" pattern - a naive majority vote across toolchains would have picked the wrong answer here, similar to what was already found once in STM32CubeWB. Fixed EWARM's ROM/RAM end symbols and GCC's FLASH/RAM `LENGTH` to 2048K/512K in all 6 EWARM `.icf` + 12 GCC `.ld` files.

### 3. NUCLEO-F767ZI (STM32F767ZIT6, 2MB flash / 512KB RAM) - 25 examples, Keil alone wrong

Keil ships no explicit `.sct` scatter file for these projects - the project's own `<Cpu>` device-descriptor line in `Project.uvprojx` is what it actually links against - and that line declared only 320K RAM (`IRAM(0x20000000-0x2004FFFF)`) instead of the chip's real 512K. Confirmed against GCC/IAR agreement on 512K for the same projects, and cross-checked across two different Keil device-pack versions used by different examples on this board (2.3.3 and 2.7.5), ruling out a pack-specific fluke rather than a real content bug. Fixed the `IRAM` range to `0x20000000-0x2007FFFF` in all 25 files.

The same board's plain `Templates` project (as opposed to `Templates_LL`, which already agrees on 512K across all 3 toolchains and served as the gold standard for this finding) had this exact same bug in both its GCC `.ld` and Keil `.uvprojx`, with only its own IAR `.icf` correct - fixed those 2 files too.

### Test plan

No local ARM toolchain (arm-none-eabi-gcc/IAR/Keil) available to compile/link-test these, so verification relied on address-arithmetic cross-referencing for each finding against multiple independent references: `Templates`/`Templates_LL` gold standards, sibling toolchain files of the same project, and checking `_estack`/actual linker symbol usage rather than trusting `MEMORY{}`/`Cpu`-line declarations alone.

### Note on scope

A 4th candidate was found (STM32F7308-DISCO / STM32F7508-DISCO, flash-less QSPI-execute-in-place parts where Keil ships with no scatter file at all and falls back to a non-functional 64KB internal-flash default) but is **not** included in this PR - fixing it would require authoring a new Keil scatter file for QSPI XIP from scratch rather than correcting an existing value, which is a larger, more design-heavy change that deserves its own separate scrutiny/PR rather than being bundled here.

### Disclosure

Generative AI (Claude) was used to help investigate this (systematic cross-toolchain linker script comparison) and implement/verify the fixes. All changes were reviewed by me before submission.
